### PR TITLE
Update multiarch.yml

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -50,11 +50,6 @@ jobs:
 
     steps:
 
-    - name: Set up QEMU for amd64 and arm64
-      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
-      with:
-        platforms: linux/amd64,linux/arm64
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 


### PR DESCRIPTION
QEMU not needed when using Depot for builds