### PR TITLE
Update multiarch.yml

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -50,9 +50,6 @@ jobs:
 
     steps:
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
-
     - name: Set up Depot CLI
       uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5
 


### PR DESCRIPTION
Buildx no longer needed when using Depot for builds